### PR TITLE
Bug fixes

### DIFF
--- a/gamemodes/core/account/account.inc
+++ b/gamemodes/core/account/account.inc
@@ -104,13 +104,6 @@ hook OnPlayerPassedBanCheck(playerid) {
             MySQL_BindInt(stmt_loadPlayerArmy, 0, Player_GetAccountID(playerid));
 	        MySQL_ExecuteParallel_Inline(stmt_loadPlayerArmy, using inline OnArmyLoad);
             Account_PromptLogin(playerid, playerHash);
-
-            // Reasoning behind this
-            // Allows the smooth transition between Login menu
-            // and when it forces Spawn the player, this work-around
-            // fixes the issue where you can see OnPlayerRequestClass for
-            // a split second.
-            TogglePlayerSpectating(playerid, true);
         }
         else {
             Account_PromptRegister(playerid);

--- a/gamemodes/core/account/account_create.inc
+++ b/gamemodes/core/account/account_create.inc
@@ -32,7 +32,7 @@ stock Account_PromptRegister(playerid) {
     }
 
     new
-        string[MAX_PLAYER_NAME + 32];
+        string[48 + MAX_PLAYER_NAME + 16];
     format(string, sizeof(string), RegisterDialogMessage, playerid, SERVER_NAME);
 
     Dialog_ShowCallback(playerid,
@@ -83,6 +83,7 @@ static Account_InsertToDatabase(playerid, const hash[]) {
 
         CallLocalFunction("OnPlayerRegister", "i", playerid);
         PlayerFirstTime[playerid] = true;
+        TogglePlayerSpectating(playerid, false);
         Player_SetLoginStatus(playerid, true);
         Class_SelectionState(playerid, true);
     }

--- a/gamemodes/core/player/player_arrest.inc
+++ b/gamemodes/core/player/player_arrest.inc
@@ -6,7 +6,7 @@ new
 
 hook OnPlayerDeath(playerid, killerid, reason)
 {
-    if(Player_IsLEO(killerid) && Player_GetWantedLevel(playerid) >= 3)
+    if(killerid != INVALID_PLAYER_ID && Player_IsLEO(killerid) && Player_GetWantedLevel(playerid) >= 3)
     {
         if(Player_GetWantedLevel(playerid) >= 10) {
             foreach(new i : Player) {

--- a/gamemodes/core/player/player_class.inc
+++ b/gamemodes/core/player/player_class.inc
@@ -324,27 +324,23 @@ hook OnPlayerRequestClass(playerid, classid) {
 	return 1;
 }
 
-hook OnPlayerSpawn(playerid)
+hook OnPlayerRequestSpawn(playerid)
 {
-	if(Player_GetClass(playerid) == TEAM_ARMY && !Player_GetArmy(playerid))
-	{
-		Class_SelectionState(playerid, true);
-        ForceClassSelection(playerid);
-        TogglePlayerSpectating(playerid, true);
-        TogglePlayerSpectating(playerid, false);
-		Player_SetBoughtSkin(playerid, true);
-		SendServerMsg(playerid, "You're not authorised to use Army skins");
-	}
-	else if(Player_GetClass(playerid) == TEAM_ARMY && IsPlayerBlacklisted(playerid))
-	{
-		Class_SelectionState(playerid, true);
-        ForceClassSelection(playerid);
-        TogglePlayerSpectating(playerid, true);
-        TogglePlayerSpectating(playerid, false);
-		Player_SetBoughtSkin(playerid, true);
-		SendServerMsg(playerid, "You're Blacklisted from the Army Team by the Administration");
-	}
-	return 1;
+  if(Player_GetClass(playerid) == TEAM_ARMY)
+  {
+    Player_SetBoughtSkin(playerid, true);
+
+    if(!Player_GetArmy(playerid))
+    {
+      SendServerMsg(playerid, "You're not authorised to use Army skins");
+    }
+    else if(IsPlayerBlacklisted(playerid))
+    {
+      SendServerMsg(playerid, "You're Blacklisted from the Army Team by the Administration");
+    }
+    return 0;
+  }
+  return 1;
 }
 
 timer void:ForceSpawnPlayer[GetPlayerPing(playerid)](playerid) {
@@ -361,6 +357,8 @@ hook OnPlayerConnect(playerid) {
 	PlayerSkin[playerid] = 0;
     PlayerClass[playerid] = -1;
 	PlayerClassState[playerid] = true;
+
+	TogglePlayerSpectating(playerid, true);
 	return 1;
 }
 


### PR DESCRIPTION
 * Use the spectator mode on the registration screen to not skip to the class selection in case of an invalid input in the registration dialog.
 * Use the `OnPlayerRequestSpawn` callback instead of `OnPlayerSpawn` to prevent players without permission from spawning with the Army class.
 * Avoid the `array index out of bounds` crash on the `OnPlayerDeath` callback, ensuring that the `killerid` parameter value is a valid player.