### PR TITLE
Reduced length of password column

### DIFF
--- a/scriptfiles/players.sql
+++ b/scriptfiles/players.sql
@@ -2,7 +2,7 @@ CREATE TABLE IF NOT EXISTS players
 (
     u_id int(11) NOT NULL AUTO_INCREMENT,
     username varchar(24) NOT NULL,
-    password char(250) NOT NULL,
+    password char(60) NOT NULL,
     register_date DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP(),
     last_login DATETIME DEFAULT NULL
     PRIMARY KEY


### PR DESCRIPTION
BCrypt's max length is 60, 250 length takes +190 byte from hardware space per player.