### PR TITLE
SQL typo fix and improves

### DIFF
--- a/scriptfiles/atms.sql
+++ b/scriptfiles/atms.sql
@@ -1,4 +1,4 @@
-CREATE TABLE atms (
+CREATE TABLE IF NOT EXISTS atms (
     atm_id int(11) NOT NULL AUTO_INCREMENT,
     atm_x float NOT NULL,
     atm_y float NOT NULL,

--- a/scriptfiles/players.sql
+++ b/scriptfiles/players.sql
@@ -4,7 +4,7 @@ CREATE TABLE IF NOT EXISTS players
     username varchar(24) NOT NULL,
     password char(60) NOT NULL,
     register_date DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP(),
-    last_login DATETIME DEFAULT NULL
+    last_login DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP(),
     PRIMARY KEY
         (u_id),
     UNIQUE KEY


### PR DESCRIPTION
DEFAULT value of login_date was NULL and it was returning a error.
 IF NOT EXISTS was missing in atms table and it was causing an error on every server start when SETUP_TABLE is true.